### PR TITLE
Tidy up of image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,8 @@ RUN pip install -r requirements.txt
 # updating to compatible to latest version of alarmdecoder
 RUN pip install git+https://github.com/nutechsoftware/alarmdecoder
 
-#RUN mkdir instance \
-# && chown -R alarmdecoder:alarmdecoder .
+RUN mkdir instance \
+ && chown -R alarmdecoder:alarmdecoder .
 
 USER alarmdecoder
 #moving to start

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:2.7-slim
 
+# this list of deps is taken from the alarmdecoder README, with a few removed
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    # this list of deps is taken from the alarmdecoder README, with a few removed
     sendmail libffi-dev build-essential libssl-dev curl libpcre3-dev libpcre++-dev zlib1g-dev libcurl4-openssl-dev autoconf automake avahi-daemon locales dosfstools sqlite3 git sudo \
  && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,8 @@ RUN pip install -r requirements.txt
 # updating to compatible to latest version of alarmdecoder
 RUN pip install git+https://github.com/nutechsoftware/alarmdecoder
 
-RUN mkdir instance \
- && chown -R alarmdecoder:alarmdecoder .
+#RUN mkdir instance \
+# && chown -R alarmdecoder:alarmdecoder .
 
 USER alarmdecoder
 #moving to start

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,11 +21,15 @@ WORKDIR /opt/alarmdecoder-webapp
 
 RUN pip install -r requirements.txt
 
+# updating to compatible to latest version of alarmdecoder
+RUN pip install git+https://github.com/nutechsoftware/alarmdecoder
+
 RUN mkdir instance \
  && chown -R alarmdecoder:alarmdecoder .
 
 USER alarmdecoder
-RUN python manage.py initdb
+#moving to start
+#RUN python manage.py initdb
 USER root
 
 # sqlite db is stored here

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,7 @@ RUN mkdir instance \
  && chown -R alarmdecoder:alarmdecoder .
 
 USER alarmdecoder
-#moving to start
-#RUN python manage.py initdb
+RUN python manage.py initdb
 USER root
 
 # sqlite db is stored here

--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ You can then access AlarmDecoder at `http://<host_ip>:5000`.
 This container exposes the gunicorn workers directly, it's recommended that set
 up an nginx reverse proxy in front of the app.
 
-You'll also likely want to created a named or mounted volume to persist the
-configuration and logging, which lives at `/opt/alarmdecoder-webapp/instance`.
+You'll also likely want to created a named volume (do not use a bind mount) to persist the configuration and logging, which lives at `/opt/alarmdecoder-webapp/instance`. You can create named volumes using the `volume create` command.
 
 A complete docker-compose configuration might look something like:
 

--- a/start.sh
+++ b/start.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -e
 
-# setting perms
-mkdir instance && chown -R alarmdecoder:alarmdecoder .
-
 # init db
 python manage.py initdb
 

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+# init db
+python manage.py initdb
+
 # Make sure the alarmdecoder user has access to the USB device. I've confirmed
 # this does not change the permission bits outside of the docker container.
 chmod o+rw /dev/ttyUSB* || echo "no USB devices found in container, continuing"

--- a/start.sh
+++ b/start.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -e
 
-# init db
-python manage.py initdb
-
 # Make sure the alarmdecoder user has access to the USB device. I've confirmed
 # this does not change the permission bits outside of the docker container.
 chmod o+rw /dev/ttyUSB* || echo "no USB devices found in container, continuing"

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+# setting perms
+mkdir instance && chown -R alarmdecoder:alarmdecoder .
+
 # init db
 python manage.py initdb
 


### PR DESCRIPTION
Hi,

I updated the readme to clarify the use of a named volumes (instead of bind mount). The bind out approach runs into user permission errors whereas the named volume approach matches best-practice (and prevents having to make changes to your start.sh or docker file). I also instructed pip to pull the latest version of the alarmdecoder python library from GitHub as the image needs to be bound to >=1.13 to avoid breaking the API. 
